### PR TITLE
Encode ordered dicts as regular dicts with ruamel

### DIFF
--- a/snakebids/io/yaml.py
+++ b/snakebids/io/yaml.py
@@ -1,4 +1,6 @@
+import collections
 from pathlib import Path, PosixPath, WindowsPath
+from typing import Any, OrderedDict
 
 from ruamel.yaml import YAML, Dumper
 
@@ -12,8 +14,13 @@ def get_yaml_io():
         return dumper.represent_scalar(
             "tag:yaml.org,2002:str",
             str(data),
-        )
+        )  # type: ignore
+
+    def to_dict(dumper: Dumper, data: OrderedDict[Any, Any]):
+        return dumper.represent_dict(dict(data))
 
     yaml.representer.add_representer(PosixPath, path2str)
     yaml.representer.add_representer(WindowsPath, path2str)
+    yaml.representer.add_representer(collections.OrderedDict, to_dict)
+    yaml.representer.add_representer(OrderedDict, to_dict)
     return yaml

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -298,7 +298,7 @@ def needs_docker(container: str):
                 sp.run(["docker", "image", "inspect", container], check=True)
             except sp.CalledProcessError as err:
                 if not (
-                    match := re.match(r"snakebids/([\w\-])+\:[a-zA-Z0-9\-]+", container)
+                    match := re.match(r"snakebids/([\w\-]+)\:[a-zA-Z0-9\-]+", container)
                 ):
                     pytest.fail(
                         f"Unrecognized docker image: {container}. Should be "
@@ -307,8 +307,8 @@ def needs_docker(container: str):
                 container_id = match[1]
                 pytest.fail(
                     f"{container} is not built on this machine. To build container, "
-                    f"run `poetry run poe build-container {container_id}`. To skip "
-                    f"docker tests, use '-m \"not docker\"'. (got error {err})"
+                    f"run:\n\n\t`poetry run poe build-container {container_id}`\n\nTo "
+                    f"skip docker tests, use '-m \"not docker\"'.\n\n(error:) {err}"
                 )
             return func(*args, **kwargs)
 

--- a/snakebids/tests/test_template.py
+++ b/snakebids/tests/test_template.py
@@ -304,3 +304,36 @@ def test_template_dry_runs_successfully(tmp_path: Path, build: BuildBackend, ven
         print(cmd.stderr, file=sys.stderr)
         raise
     assert "All set" in cmd.stdout.decode()
+
+
+def test_template_dry_runs_with_current_repository(tmp_path: Path):
+    app_name = "snakebids_app"
+    data = get_empty_data(app_name, "setuptools")
+
+    copier.run_copy(
+        str(Path(itx.first(snakebids.__path__), "project_template")),
+        tmp_path / app_name,
+        data=data,
+        unsafe=True,
+    )
+    app_path = tmp_path / app_name
+    cmd = sp.run(
+        [
+            sys.executable,
+            app_path / app_name / "run.py",
+            app_path / "tests/data",
+            app_path / "tests/results",
+            "participant",
+            "-c1",
+            "--skip-bids-validation",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    try:
+        cmd.check_returncode()
+    except Exception:
+        print(cmd.stdout.decode())
+        print(cmd.stderr.decode(), file=sys.stderr)
+        raise
+    assert "All set" in cmd.stdout.decode()


### PR DESCRIPTION
Older snakemake versions read config files as ordered dicts. Ruamel would then render these back to yaml with an !!omap type, which would then in turn be interpreted by pyyaml as lists of tuple pairs.

Fix by handling all OrderedDicts as regular dicts

Additionally, test a template dry run using the current repository state (where previously we used only the latest pip release)

## Proposed changes

Describe the changes implemented in this pull request. If the changes fix a bug or resolves a feature request, be sure to link the issue (and explain how the changes address the issue). Be sure to select a label describing the PR (e.g. maintenance).

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.